### PR TITLE
Fixed an issue when PR does not have a Description.

### DIFF
--- a/lib/pr_releasenotes.rb
+++ b/lib/pr_releasenotes.rb
@@ -128,9 +128,9 @@ module PrReleasenotes
     def get_releasenotes_for_prs(prs)
       notes = prs.reduce([]) { |notes, pr|
         # Get release notes section
-        body = pr[:body].strip.slice(config.relnotes_regex, config.relnotes_group)
-        unless body.nil?
+        unless pr[:body].nil?
           # Release notes exist for this PR, so do some cleanup
+          body = pr[:body].strip.slice(config.relnotes_regex, config.relnotes_group)
           body.gsub! /^<!--.+?(?=-->)-->/m, '' # strip off (multiline) comments
           body.gsub! /^\r?\n/, ''             # and empty lines
         end


### PR DESCRIPTION
I was getting 
```
/Library/Ruby/Gems/2.3.0/gems/pr_releasenotes-0.0.1/lib/pr_releasenotes.rb:132:in `block in get_releasenotes_for_prs': undefined method `strip' for nil:NilClass (NoMethodError)
	from /Library/Ruby/Gems/2.3.0/gems/pr_releasenotes-0.0.1/lib/pr_releasenotes.rb:129:in `each'
	from /Library/Ruby/Gems/2.3.0/gems/pr_releasenotes-0.0.1/lib/pr_releasenotes.rb:129:in `reduce'
	from /Library/Ruby/Gems/2.3.0/gems/pr_releasenotes-0.0.1/lib/pr_releasenotes.rb:129:in `get_releasenotes_for_prs'
	from /Library/Ruby/Gems/2.3.0/gems/pr_releasenotes-0.0.1/lib/pr_releasenotes.rb:36:in `run'
	from /Library/Ruby/Gems/2.3.0/gems/pr_releasenotes-0.0.1/exe/pr_releasenotes:11:in `<top (required)>'
	from /usr/local/bin/pr_releasenotes:22:in `load'
	from /usr/local/bin/pr_releasenotes:22:in `<main>'
```
for PRs with no Description.