### PR TITLE
#3 - Enable support for start/end commits and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ will generate release notes from your latest release tag to the tip of the maste
 
 ## Why this tool vs others
 
-There are quite a few online tools for generating release notes based on github history, but all the ones I've found rely on commit messages. This makes them inflexible, since it would require rewriting commit history in order to make any changes to the generated notes.
+There are quite a few online tools for generating release notes based on github history, but all the ones I've found rely on commit messages. This makes them inflexible, since it would require rewriting commit history in order to make any changes to the generated notes. In addition, using commit messages forces irrelevant information such as `fixed typo`, `reverted incorrect commit`, and `updated tests/docs` into the release notes.
 
-This tool uses the pull request descriptions, so the release notes for any version can be updated at any time by simply updating the corresponding pull request's description and rerunning this tool.
+This tool uses pull request descriptions, so the release notes for any version can be updated at any time by simply updating the corresponding pull request's description and rerunning this tool. In addition, pull request descriptions can have a separate brief and focused section to expose only the necessary information into the release notes. 
 
-Secondly, this tool provides the additional option to post the release notes back to the github releases page.
+Finally, this tool provides the additional option to post the release notes back to the github releases page.
 
 ## Installation
 
@@ -34,20 +34,18 @@ Or install it yourself as:
 
 ## Usage
 
-The minimum configuration necessary to run the tool is the repo, github token and a start release tag:
+The minimum configuration necessary to run the tool is the repo, github token and a starting tag or commit sha:
 
-    $ pr_releasenotes --repo <user/repo> --token <token> --start <latest_tagged_release>
+    $ pr_releasenotes --repo <user/repo> --token <token> --start <start_tag|sha>
 
-Additional options can be specified either by passing a yaml configuration to the included executable:
+Additional options can be specified either by passing a yaml configuration to the executable:
 
-    $ pr_releasenotes --config <config.yaml> --token <token> --start <start_version> --end <end_version> --branch <non-default branch>
+    $ pr_releasenotes --config <config.yaml> --token <token> --start <start_tag|sha> --end <end_tag|sha> --branch <non-default branch>
 
 or by invoking the gem directly from ruby code:
 
 ```ruby
 require 'pr_releasenotes'
-
-include PrReleasenotes
 
 PrReleasenotes.configure do |config|
   config.repo('user/repo')
@@ -55,7 +53,7 @@ PrReleasenotes.configure do |config|
   config.parse_args(ARGV)
 end
 
-ReleaseNotes.new.run
+PrReleasenotes.run
 ```
 
 Get a brief usage summary by running
@@ -64,6 +62,27 @@ Get a brief usage summary by running
 
 
 See the [examples folder](examples) for some sample yaml configuration files.
+
+### Running as part of a release build
+
+This tool can be invoked right after a release build to automatically add release notes to a newly created release.
+
+#### Regular releases
+
+For regular releases where a previous release already exists, and a new release is being created, this tool can be invoked after the release is built by using the following form:
+
+    $ pr_releasenotes --repo <user/repo> --token <token> --end <current_release_tag>
+    
+The tool will set the start_tag to the latest tagged release prior to the current one and generate release notes from that release to the current one.
+
+#### Initial release
+
+For the initial release from a repo, there is no previous release, so the tool must be run with an explicit start sha or tag:
+
+    $ pr_releasenotes --repo <user/repo> --token <token> --start <commit_sha> --end <current_release_tag>
+ 
+Both the `--start` and `--end` parameters support sha values as well as tags, so release notes can be generated between any two tags or commits.
+
 
 ### Github token permissions
 

--- a/examples/custom_config.yaml
+++ b/examples/custom_config.yaml
@@ -4,7 +4,7 @@
 #
 
 # Name of your repo in user/repo format
-repo:
+# repo:
 
 # Release notes parsing options. Note that comments will always get stripped
 
@@ -14,6 +14,7 @@ relnotes_group: 1 # group to capture from the regex
 
 # Enable categorization
 categorize: true
+relnotes_hdr_prefix: '### '
 
 # Update to your own jira server
 jira_baseurl: 'https://issues.apache.org/jira/browse/'

--- a/examples/default_config.yaml
+++ b/examples/default_config.yaml
@@ -1,5 +1,6 @@
 #
-# Sample configuration containing default configuration values
+# Sample configuration containing default values.
+# At least one of the following options must be uncommented to use this configuration file
 #
 
 # Name of your repo in user/repo format. Defaults to nil and must be overridden in the yaml or on the cmd line.
@@ -8,19 +9,19 @@
 # Release notes will be pulled from PRs merged to this branch. Defaults to master.
 # branch: master
 
-# Version range from which release notes should be gathered
+# Tag range from which release notes should be gathered
 
-# Extract pull requests starting from this version. Defaults to nil for latest published release. Override if
+# Extract pull requests starting from this tag. Defaults to nil for latest published release. Override if
 # there are no published releases yet.
 # Note: Although this parameter is listed here for completeness, this will likely be specified on the cmd line
 # since its value will vary with each release.
-# start_version:
+# start_tag:
 
 # Defaults to nil for latest commit. nil will also skip the creation of a github release
-# end_version:
+# end_tag:
 
 # If all your tags have a common prefix, add that here, and use just the varying suffix as the 
-# start/end version arguments. Defaults to blank.
+# start/end tag arguments. Defaults to blank.
 # tag_prefix: 
 
 # Short sha uniqueness threshold. Shas shorter than this may collide with other commits. When searching for
@@ -37,7 +38,9 @@
 
 # Release notes parsing options. Note that comments will always get stripped
 
-# By default, the entire PR description will be used.
+# By default, only the PR titles will be used, so match nothing from the description
+# relnotes_regex: '/.\A/'
+# To use the entire PR description instead
 # relnotes_regex: '/.*/m'
 
 # group to capture from the above regex
@@ -56,7 +59,7 @@
 # category_default: '<!--99-->Other'
 
 # Add a prefix to the release notes items
-# relnotes_hdr_prefix: '### '
+# relnotes_hdr_prefix: '* '
 
 
 # Optional jira url to auto link all strings matching a jira ticket pattern

--- a/exe/pr_releasenotes
+++ b/exe/pr_releasenotes
@@ -2,10 +2,8 @@
 
 require 'pr_releasenotes'
 
-include PrReleasenotes
-
 PrReleasenotes.configure do |config|
   config.parse_args(ARGV)
 end
 
-ReleaseNotes.new.run
+PrReleasenotes.run


### PR DESCRIPTION
  - Better config defaults when categorize=false
  - Corrected the method for figuring out the start tag
  - Fixes #3 to make release notes work for the initial release of a repo