### PR TITLE
include `--full-release` option to set as the latest full release

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ will generate release notes from your latest release tag to the tip of the maste
 
 There are quite a few online tools for generating release notes based on github history, but all the ones I've found rely on commit messages. This makes them inflexible, since it would require rewriting commit history in order to make any changes to the generated notes. In addition, using commit messages forces irrelevant information such as `fixed typo`, `reverted incorrect commit`, and `updated tests/docs` into the release notes.
 
-This tool uses pull request descriptions, so the release notes for any version can be updated at any time by simply updating the corresponding pull request's description and rerunning this tool. In addition, pull request descriptions can have a separate brief and focused section to expose only the necessary information into the release notes. 
+This tool uses pull request descriptions, so the release notes for any version can be updated at any time by simply updating the corresponding pull request's description and rerunning this tool. In addition, pull request descriptions can have a separate brief and focused section to expose only the necessary information into the release notes.
 
 Finally, this tool provides the additional option to post the release notes back to the github releases page.
 
@@ -72,15 +72,17 @@ This tool can be invoked right after a release build to automatically add releas
 For regular releases where a previous release already exists, and a new release is being created, this tool can be invoked after the release is built by using the following form:
 
     $ pr_releasenotes --repo <user/repo> --token <token> --end <current_release_tag>
-    
+
 The tool will set the start_tag to the latest tagged release prior to the current one and generate release notes from that release to the current one.
+
+By default, a release will be prerelease. Use `--full-release` to create a full release to the repo.
 
 #### Initial release
 
 For the initial release from a repo, there is no previous release, so the tool must be run with an explicit start sha or tag:
 
     $ pr_releasenotes --repo <user/repo> --token <token> --start <commit_sha> --end <current_release_tag>
- 
+
 Both the `--start` and `--end` parameters support sha values as well as tags, so release notes can be generated between any two tags or commits.
 
 

--- a/lib/pr_releasenotes.rb
+++ b/lib/pr_releasenotes.rb
@@ -241,16 +241,16 @@ module PrReleasenotes
           # Found existing release, so update it
           log.info "Found existing #{release.draft? ? 'draft ' : ''}#{release.prerelease? ? 'pre-' : ''}release with tag #{tag_name} at #{release.html_url}#{release.body.nil? || release.body.empty? ? '' : " with body: #{release.body}"}"
           begin
-            release = git_client.update_release(release.url, { :name => tag_name, :body => notes_str, :draft => false, :prerelease => true })
-            log.info "Updated pre-release #{release.id} at #{release.html_url} with body\n\n #{notes_str}"
+            release = git_client.update_release(release.url, { :name => tag_name, :body => notes_str, :draft => false, :prerelease => config.prerelease })
+            log.info "Updated #{config.prerelease ? "prerelease" : "full release"} #{release.id} at #{release.html_url} with body\n\n #{notes_str}"
           rescue Octokit::NotFound
             raise "Unable to post release to github. Ensure your token has the right permissions."
           end
         rescue Octokit::NotFound
           # no existing release, so try create a new one for this end_tag
           begin
-            release = git_client.create_release(config.repo, tag_name, { :name => tag_name, :body => notes_str, :draft => false, :prerelease => true })
-            log.info "Created pre-release #{release.id} at #{release.html_url} with body\n\n #{notes_str}"
+            release = git_client.create_release(config.repo, tag_name, { :name => tag_name, :body => notes_str, :draft => false, :prerelease => config.prerelease })
+            log.info "Created #{config.prerelease ? "prerelease" : "full release"} #{release.id} at #{release.html_url} with body\n\n #{notes_str}"
           rescue Octokit::NotFound
             raise "Unable to post release to github. Ensure your token has the right permissions."
           end

--- a/lib/pr_releasenotes/configuration.rb
+++ b/lib/pr_releasenotes/configuration.rb
@@ -22,7 +22,7 @@ module PrReleasenotes
     require "pr_releasenotes/version"
 
     attr_accessor :repo, :token, :tag_prefix, :min_sha_size, :start_tag, :end_tag,
-                  :branch, :include_all_prs, :github_release, :relnotes_group,
+                  :branch, :include_all_prs, :github_release, :prerelease, :relnotes_group,
                   :categorize, :category_prefix, :category_default, :relnotes_hdr_prefix,
                   :jira_baseurl, :auto_paginate, :log
 
@@ -48,6 +48,8 @@ module PrReleasenotes
       @include_all_prs = true
       # Finish by posting release notes to github
       @github_release = false
+      # Release notes are defaulted to be prerelease
+      @prerelease = true
 
       # Release notes parsing options. Note that comments will always get stripped
       # By default, only the PR titles will be used, so match nothing from the description
@@ -124,6 +126,9 @@ module PrReleasenotes
         opts.separator ''
         opts.on('-p', '--post-to-github', 'Create/update release on github') do
           @github_release = true
+        end
+        opts.on('-f', '--full-release', 'Create a full release') do
+          @prerelease = false
         end
 
         opts.separator ''


### PR DESCRIPTION
#### When using Jenkins to create a release, the `0.0.2` version hard codes to always creating a prerelease. 

#### I added an option `--full-release` to create a [full release](https://developer.github.com/v3/repos/releases/#create-a-release). This means the developers don't need to manually toggle the release notes to be the latest release. 

#### The changes are also backward compatible.

### example usage:
 `pr_releasenotes --repo <repo_name> --token <github_token> --start <start_tag> --end <end_tag> --full-release --post-to-github`